### PR TITLE
Use the spread operator to pass in any saml configuration

### DIFF
--- a/src/WebLoginAuth.ts
+++ b/src/WebLoginAuth.ts
@@ -51,21 +51,16 @@ export class WebLoginAuth {
     // Configure passport for SAML
     this.saml = new SamlStrategy(
       {
-        name:  this.config.saml.name,
-        path: this.config.saml.path,
-        callbackUrl: this.config.saml.callbackUrl,
-        issuer: this.config.saml.issuer,
+        ...this.config.saml,
         logoutUrl: this.config.saml.loginPath,
-        forceAuthn: this.config.saml.forceAuthn,
-        decryptionPvk: this.config.saml.decryptionPvk,
-        entryPoint: idps[this.config.saml.idp].entryPoint,
-        cert: idps[this.config.saml.idp].cert,
+        entryPoint: idps_1.default[this.config.saml.idp].entryPoint,
+        cert: idps_1.default[this.config.saml.idp].cert,
         wantAssertionsSigned: true,
         signatureAlgorithm: 'sha256',
         identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
         acceptedClockSkewMs: 60000,
         skipRequestCompression: false,
-        passReqToCallback: true,
+        passReqToCallback: true
       },
       (req, profile, done) => {
         const user = attrMapper(profile);

--- a/src/WebLoginAuth.ts
+++ b/src/WebLoginAuth.ts
@@ -51,7 +51,7 @@ export class WebLoginAuth {
     // Configure passport for SAML
     this.saml = new SamlStrategy(
       {
-        logoutUrl: this.config.saml.loginPath,,,
+        logoutUrl: this.config.saml.loginPath,
         entryPoint: idps[this.config.saml.idp].entryPoint,
         cert: idps[this.config.saml.idp].cert,
         wantAssertionsSigned: true,

--- a/src/WebLoginAuth.ts
+++ b/src/WebLoginAuth.ts
@@ -51,16 +51,16 @@ export class WebLoginAuth {
     // Configure passport for SAML
     this.saml = new SamlStrategy(
       {
-        ...this.config.saml,
-        logoutUrl: this.config.saml.loginPath,
-        entryPoint: idps_1.default[this.config.saml.idp].entryPoint,
-        cert: idps_1.default[this.config.saml.idp].cert,
+        logoutUrl: this.config.saml.loginPath,,,
+        entryPoint: idps[this.config.saml.idp].entryPoint,
+        cert: idps[this.config.saml.idp].cert,
         wantAssertionsSigned: true,
         signatureAlgorithm: 'sha256',
         identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
         acceptedClockSkewMs: 60000,
         skipRequestCompression: false,
-        passReqToCallback: true
+        passReqToCallback: true,
+        ...this.config.saml
       },
       (req, profile, done) => {
         const user = attrMapper(profile);

--- a/src/WebLoginAuth.ts
+++ b/src/WebLoginAuth.ts
@@ -60,7 +60,7 @@ export class WebLoginAuth {
         acceptedClockSkewMs: 60000,
         skipRequestCompression: false,
         passReqToCallback: true,
-        ...this.config.saml
+        ...this.config.saml,
       },
       (req, profile, done) => {
         const user = attrMapper(profile);
@@ -75,7 +75,7 @@ export class WebLoginAuth {
           eduPersonPrincipalName: user.eduPersonPrincipalName,
           eduPersonScopedAffiliation: user.eduPersonScopedAffiliation,
           sn: user.sn,
-        }
+        };
         done(null, account);
       }
     );
@@ -278,7 +278,7 @@ export class WebLoginAuth {
    */
   public generateServiceProviderMetadata = () => {
     return this.saml.generateServiceProviderMetadata(this.config.saml.decryptionCert, this.config.saml.cert);
-  }
+  };
 }
 
 // Singleton client for default consumption


### PR DESCRIPTION
# NOT READY FOR REVIEW

# Summary
- Allow `additionalParams` and any other saml configs to pass down.
- This provides the ability to do this:
```
    additionalParams: {
      Signature: process.env.WEBLOGIN_AUTH_SIGN_SIGNATURE
    }
```
which is the key to eeevvverrrrythiiinng.....


# Review By (Date)
- When does this need to be reviewed by?

# Criticality
- How critical is this PR on a 1-10 scale?

# Review Tasks

## Setup tasks and/or behavior to test

1. Check out this branch
2. Navigate to...
3. Verify...

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- JIRA ticket(s)
- Other PRs
- Any other contextual information that might be helpful (e.g., description of a bug that this PR fixes, new functionality that it adds, etc.)
- Anyone who should be notified? (`@mention` them here)
